### PR TITLE
Test against Rails 7.1

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -7,9 +7,9 @@ appraise "rails_edge" do
 end
 
 appraise "rails_71" do
-  gem "rails", "~> 7.1.0.rc2"
-  gem "railties", "~> 7.1.0.rc2"
-  gem "activesupport", "~> 7.1.0.rc2"
+  gem "rails", "~> 7.1.0"
+  gem "railties", "~> 7.1.0"
+  gem "activesupport", "~> 7.1.0"
 end
 
 appraise "rails_70" do

--- a/gemfiles/rails_71.gemfile
+++ b/gemfiles/rails_71.gemfile
@@ -3,8 +3,8 @@
 source "https://rubygems.org"
 
 gem "rake", "~> 13.0"
-gem "rails", "~> 7.1.0.rc2"
-gem "railties", "~> 7.1.0.rc2"
-gem "activesupport", "~> 7.1.0.rc2"
+gem "rails", "~> 7.1.0"
+gem "railties", "~> 7.1.0"
+gem "activesupport", "~> 7.1.0"
 
 gemspec path: "../"


### PR DESCRIPTION
Since [Rails 7.1 has already been released](https://rubyonrails.org/2023/10/5/Rails-7-1-0-has-been-released), I have removed the 'rc' notation.